### PR TITLE
fixed Eye toggling shows Opposite behaviour 

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -123,7 +123,7 @@ function Login() {
               className="absolute right-3 top-3 cursor-pointer"
               onClick={() => setShowPassword((prev) => !prev)}
             >
-              {showPassword ? <AiOutlineEyeInvisible size={20} /> : <AiOutlineEye size={20} />}
+              {showPassword ? <AiOutlineEye size={20} /> : <AiOutlineEyeInvisible size={20} />}
             </span>
           </div>
 

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -211,9 +211,9 @@ function Signup() {
               onClick={() => setShowPassword((prev) => !prev)}
             >
               {showPassword ? (
-                <AiOutlineEyeInvisible size={20} />
-              ) : (
                 <AiOutlineEye size={20} />
+              ) : (
+                <AiOutlineEyeInvisible size={20} />
               )}
             </span>
           </div>


### PR DESCRIPTION
The eye toggling is showing opposite behaviour like when eye is open then the pass will be hidden and on slash eye the pass will be shown to the user . so i fixed it by changing the position of slash eye icon with the eye icon in the ternary operator . It includes the fixes for both signup and login page .
Fixes #156 


## Type of change

Please give a X on it which is applicable

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor Code
- [ ] A documentation update
- [ ] Others(mentioned in the issue number)

# How Has This Been Tested?
it will be tested by clicking multiple times to the eye icon to check its functionality .

# Screenshots and Videos:

![Screenshot 2024-05-18 235700](https://github.com/VanshKing30/FoodiesWeb/assets/118350936/8d067845-88a3-4dd9-97a6-04c0494ecc79)
![Screenshot 2024-05-18 235649](https://github.com/VanshKing30/FoodiesWeb/assets/118350936/d2c0444a-7743-4aeb-bfd2-db0719b6608b)


# Checklist:
give a X on it which is applicable

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
