### PR TITLE
Centering news elements

### DIFF
--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -39,10 +39,10 @@ function News() {
           (
             <div className="text-gray-900 min-h-screen">
               <Navbar />
-              <h1 className="text-3xl font-bold text-center mt-20 text-white p-6">
+              <h1 className="text-3xl font-bold text-center mt-10 mb-10 text-white p-6">
                 Trending Food and Health News
               </h1>
-              <main className="mt-24 p-4">
+              <main className="p-4 flex justify-center items-center">
                 <div className="container grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
                   {articles.map((article, index) => (
                     <NewsCard key={index} article={article} />


### PR DESCRIPTION
Aligned the news elements horizontally and vertically in with the main content section of `News` page. Fixed the margin for the title. 


Fixes #219 


## Type of change

Please give a X on it which is applicable

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor Code
- [ ] A documentation update
- [ ] Others(mentioned in the issue number)
