### PR TITLE
fix: greetings workflow access token naming convention

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,4 +1,4 @@
-name: 'Greetings'
+name: "Greetings"
 
 on:
   fork:
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v1
       - uses: EddieHubCommunity/gh-action-community/src/welcome@main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           issue-message: |
             Congratulations, @${{ github.actor }}! 🎉 Thank you for creating your issue. Your contribution is greatly appreciated and we look forward to working with you to resolve the issue. Keep up the great work!
           pr-message: |
             Great job, @${{ github.actor }}! 🎉 Thank you for submitting your pull request. Your contribution is valuable and we appreciate your efforts to improve our project.
-          footer: 'We will promptly review your changes and offer feedback. Keep up the excellent work! Kindly remember to check our [contributing guidelines](https://github.com/VanshKing30/FoodiesWeb/blob/main/CONTRIBUTING.md)'
+          footer: "We will promptly review your changes and offer feedback. Keep up the excellent work! Kindly remember to check our [contributing guidelines](https://github.com/VanshKing30/FoodiesWeb/blob/main/CONTRIBUTING.md)"


### PR DESCRIPTION
Updated `greetings` workflow action token naming convention

:warning: make sure to add a new personal access token in repository secrets with name `GH_TOKEN` and give access to `issues` and `pull requests`

Fixes #257 

## Type of change

Please give a X on it which is applicable

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor Code
- [ ] A documentation update
- [X] Others(mentioned in the issue number)

# How Has This Been Tested?

I have tested this workflow on my repo: https://github.com/aayushchugh/workflows/issues/1

![image](https://github.com/VanshKing30/FoodiesWeb/assets/69336518/055b8def-a65a-43f3-984a-ce576874b0b0)


# Checklist:
give a X on it which is applicable

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
