### PR TITLE
Added floating button to scroll back to top

### DIFF
--- a/src/components/FloatBtn/FloatBtn.css
+++ b/src/components/FloatBtn/FloatBtn.css
@@ -1,0 +1,23 @@
+
+.scrollButton {
+    position: fixed;
+    bottom: 40px;
+    right: 20px;
+    background-color: #66BB6A;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 45px;
+    height: 45px;
+    font-size: 24px;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    transition: background-color 0.3s ease;
+  }
+
+  .scrollButton:hover {
+    background-color: #43A047;
+  }

--- a/src/components/FloatBtn/FloatBtn.jsx
+++ b/src/components/FloatBtn/FloatBtn.jsx
@@ -1,0 +1,17 @@
+import "./FloatBtn.css";
+
+const FloatBtn = () => {
+    const scrollToTop = () => {
+        window.scrollTo({
+          top: 0,
+          behavior: "smooth"
+        });
+      };
+      return(
+        <button class="scrollButton" onClick={scrollToTop}>
+        &#9650;
+      </button>
+      );
+};
+
+export default FloatBtn;

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -4,7 +4,8 @@ import Navbar from "../components/Navbar";
 import AOS from "aos";
 import Loader from "../components/Loader/Loader";
 import "aos/dist/aos.css";
-import Footer from "../components/Footer"
+import Footer from "../components/Footer";
+import FloatBtn from "../components/FloatBtn/FloatBtn";
 
 const About = () => {
   const [loading,setLoading] = useState(false);
@@ -198,6 +199,7 @@ const About = () => {
           </div>
         </div>
         <Footer />
+        <FloatBtn />
       </div>
       )
     }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -8,6 +8,7 @@ import Navbar from "../components/Navbar";
 import CanteenList from "../components/CanteenList";
 import Loader from "../components/Loader/Loader";
 import Footer from "../components/Footer";
+import FloatBtn from "../components/FloatBtn/FloatBtn";
 
 function Home() {
 
@@ -56,7 +57,9 @@ function Home() {
           <CanteenList canteenData = {canteenData}/>
         </div>
         <Footer />
+        <FloatBtn />
       </div>
+      
       )
     }
     </>

--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -3,6 +3,7 @@ import Navbar from "../components/Navbar";
 import NewsCard from "../components/NewsCard";
 import Loader from "../components/Loader/Loader";
 import Footer from "../components/Footer";
+import FloatBtn from "../components/FloatBtn/FloatBtn";
 
 function News() {
   const [articles, setArticles] = useState([]);
@@ -50,6 +51,7 @@ function News() {
                 </div>
               </main>
               <Footer />
+              <FloatBtn />
             </div>
           )
       }


### PR DESCRIPTION
## Description

- Added  `FloatBtn` component in `Home` , `About` and `News` pages
- Added hovering effect for the floating button as well
- On clicking the floating button, users can easily scroll back to top


Fixes #173 


## Type of change

Please give a X on it which is applicable

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactor Code
- [ ] A documentation update
- [ ] Others(mentioned in the issue number)

# How Has This Been Tested?

It has been tested on my local machine

# Video:


https://github.com/VanshKing30/FoodiesWeb/assets/115717746/56b92926-3fe7-421c-a57a-e9079cb76c9b



# Checklist:
give a X on it which is applicable

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
